### PR TITLE
Updated definitions and full_pipeline to include singularity_home for BOUNTI

### DIFF
--- a/configs/default_sg.yaml
+++ b/configs/default_sg.yaml
@@ -4,7 +4,9 @@ defaults:
   - segmentation/bounti
   - _self_
 container: "singularity"
-singularity_path: "/home/gmarti/SINGULARITY/"
+singularity_path: "/home/gmarti/SINGULARITY"
+singularity_mount: "/gpfs/home/gmarti:/gpfs/home/gmarti"
+singularity_home: "/gpfs/home/gmarti/tmp_proc"
 reconstruction:
   output_resolution: 0.8
 save_graph: False

--- a/fetpype/definitions.py
+++ b/fetpype/definitions.py
@@ -17,6 +17,7 @@ VALID_PREPRO_TAGS = [
     "output_masks",
     "singularity_path",
     "singularity_mount",
+    "singularity_home",
 ]
 
 VALID_RECON_TAGS = [
@@ -31,6 +32,7 @@ VALID_RECON_TAGS = [
     "output_res",
     "singularity_path",
     "singularity_mount",
+    "singularity_home",
 ]
 
 VALID_SEG_TAGS = [
@@ -41,4 +43,5 @@ VALID_SEG_TAGS = [
     "output_seg",
     "singularity_path",
     "singularity_mount",
+    "singularity_home",
 ]

--- a/fetpype/pipelines/full_pipeline.py
+++ b/fetpype/pipelines/full_pipeline.py
@@ -309,6 +309,7 @@ def get_seg(cfg):
                 "cfg",
                 "singularity_path",
                 "singularity_mount",
+                "singularity_home",
             ],
             output_names=["seg_volume"],
             function=run_seg_cmd,
@@ -321,6 +322,7 @@ def get_seg(cfg):
     if cfg.container == "singularity":
         seg.inputs.singularity_path = cfg.singularity_path
         seg.inputs.singularity_mount = cfg.singularity_mount
+        seg.inputs.singularity_home = cfg.singularity_home
 
     seg_pipe.connect(inputnode, "srr_volume", seg, "input_srr")
     seg_pipe.connect(seg, "seg_volume", outputnode, "seg_volume")


### PR DESCRIPTION
Really small set of changes, to adapt the new tag <singularity_home>, needed for the temporal directory that BOUNTI requires, to fetpype configuration.